### PR TITLE
widen DataSource.status to str for open-ended error variants

### DIFF
--- a/gpt_trainer_sdk/__init__.py
+++ b/gpt_trainer_sdk/__init__.py
@@ -87,18 +87,14 @@ class DataSource(BaseModel):
     uuid: str
     file_name: str
     title: str
-    status: Literal[
-        "await",
-        "queued",
-        "pending",
-        "success",
-        "extracting",
-        "chunking",
-        "embedding",
-        "error:storage",
-        "error:token",
-        "fail",
-    ]
+    # Status is `str` rather than a Literal because the backend emits open-ended
+    # error:* variants (e.g. "error:rate limit", "error:no text",
+    # "error:image upload limit", "error:invalid datasource type: ..."). Known
+    # values: await, queued, pending, downloading, extracting, chunking,
+    # embedding, success, fail, error:storage, error:token, plus other error:*
+    # strings under 64 chars. Match terminal states with:
+    #   status in {"success", "fail"} or status.startswith("error:")
+    status: str
     type: Literal["upload", "link", "google-drive", "table", "image", "qa", "video"]
 
 

--- a/tests/test_data_source_model.py
+++ b/tests/test_data_source_model.py
@@ -1,0 +1,72 @@
+"""Unit tests for the DataSource / DataSourceFull Pydantic models.
+
+These tests run by default (no `incur_costs` marker) and don't hit the API.
+"""
+
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from gpt_trainer_sdk import DataSource, DataSourceFull
+
+
+def _full_payload(**overrides):
+    base = {
+        "uuid": "ds-uuid",
+        "file_name": "doc.pdf",
+        "title": "doc.pdf",
+        "status": "success",
+        "type": "upload",
+        "created_at": datetime.now(),
+        "modified_at": datetime.now(),
+        "file_size": 1234,
+        "meta_json": "{}",
+        "tokens": 42,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        "await",
+        "queued",
+        "pending",
+        "downloading",
+        "extracting",
+        "chunking",
+        "embedding",
+        "success",
+        "fail",
+        "error:storage",
+        "error:token",
+        "error:rate limit",
+        "error:no text",
+        "error:image upload limit",
+        "error:invalid data source",
+        "error:invalid chatbot",
+        "error:invalid user",
+        "error:download",
+        "error:content type",
+        "error:not found",
+        "error:scraper rate limit",
+        "error:something brand new",
+    ],
+)
+def test_data_source_accepts_known_and_arbitrary_error_statuses(status):
+    ds = DataSourceFull(**_full_payload(status=status))
+    assert ds.status == status
+
+
+def test_data_source_invalid_type_still_rejected():
+    with pytest.raises(ValidationError):
+        DataSourceFull(**_full_payload(type="not-a-real-type"))
+
+
+def test_data_source_minimal_fields():
+    ds = DataSource(
+        uuid="x", file_name="f", title="t", status="error:rate limit", type="upload"
+    )
+    assert ds.status == "error:rate limit"


### PR DESCRIPTION
## Summary

- The backend writes open-ended \`error:*\` strings to a data source's \`status\` column (e.g. \`error:rate limit\`, \`error:no text\`, \`error:image upload limit\`, \`error:invalid datasource type: ...\`). These are not in the previous \`Literal[...]\` set, so \`get_data_sources()\` raised \`pydantic.ValidationError\` whenever a data source was in any of those states — crashing consumer polling loops.
- Widen \`DataSource.status\` from \`Literal[...]\` to \`str\` and document the known values + recommended terminal-state check (\`status in {"success", "fail"} or status.startswith("error:")\`) in a comment.
- Add a unit-test file (no \`incur_costs\` marker, runs by default) covering known statuses, arbitrary \`error:*\` variants, the \`"downloading"\` case, and confirming \`type\` is still strictly validated.

This is a type-widening change: every previously-accepted Literal value is still a valid \`str\`, so existing consumer code that compares \`ds.status == "success"\` continues to work unchanged.

## Test plan

- [x] \`uv run pytest tests/test_data_source_model.py -v\` — 24 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)